### PR TITLE
fix: parse boolean and int attributes value

### DIFF
--- a/src/lazyframe.js
+++ b/src/lazyframe.js
@@ -104,13 +104,35 @@ const Lazyframe = () => {
 
   }
 
+  function parseBoolValue(inputString, defaultVal) {
+    if (inputString === 'true') {
+      return true;
+    }
+    if (inputString === 'false') {
+      return false;
+    }
+    return defaultVal;
+  }
+
+  function parseIntValue(inputString, defaultVal) {
+    const val = parseInt(inputString);
+    return isNaN(val) ? defaultVal: val;
+  }
+
   function setup(el) {
 
     const attr = Array.prototype.slice.apply(el.attributes)
      .filter(att => att.value !== '')
      .reduce((obj, curr) => {
         let name = curr.name.indexOf('data-') === 0 ? curr.name.split('data-')[1] : curr.name;
-        obj[name] = curr.value;
+        let val = curr.value;
+        if (['autoplay','initinview'].includes(name)) {
+          val = parseBoolValue(val, settings[name])
+        }
+        if (['debounce'].includes(name)) {
+          val = parseIntValue(val, settings[name])
+        }
+        obj[name] = val;
         return obj;
      }, {});
 


### PR DESCRIPTION
Considering example:

```
<div
  class="lazyframe"
  data-vendor=""
  data-title=""
  data-thumbnail=""
  data-src=""
  data-ratio="1:1"
  data-initinview="false"
  data-autoplay="false"
></div>

```

Even-though data-autoplay="false" autoplay will be considered as true due to string value. This results in all attributes being evaluated as strings.

explicitly examing ['autoplay','initinview'] as boolean and ['debounce'] as integer will values passed as attributes correspond to preferred types